### PR TITLE
Add Kind function

### DIFF
--- a/event.go
+++ b/event.go
@@ -19,7 +19,23 @@ func (e Event) String() string {
 // EventInfo TODO
 type EventInfo interface {
 	Event() Event     // TODO
-	IsDir() bool      // TODO
+	IsDir() bool      // TODO(rjeczalik): Move to WatchInfo?
 	Name() string     // TODO
 	Sys() interface{} // TODO
+}
+
+// Kind gives generic event type of the EventInfo.Event(). The purpose is to
+// hint the Dispatch whether the event created a file or directory or it deleted
+// one. The possible values of Kind are Create or Delete, any other value is
+// ignored by the Dispatch.
+//
+// TODO(rjeczalik): Unexported || Part of EventInfo?
+func Kind(e Event) Event {
+	switch e {
+	case Create, Delete:
+		return e
+	default:
+		ev, _ := ekind[e]
+		return ev
+	}
 }

--- a/event_linux.go
+++ b/event_linux.go
@@ -53,3 +53,9 @@ var estr = map[Event]string{
 	IN_CLOSE:         "syscall.IN_CLOSE",
 	IN_MOVE:          "syscall.IN_MOVE",
 }
+
+var ekind = map[Event]Event{
+	syscall.IN_MOVED_FROM:  Create,
+	syscall.IN_MOVED_TO:    Delete,
+	syscall.IN_DELETE_SELF: Delete,
+}

--- a/event_stub.go
+++ b/event_stub.go
@@ -27,3 +27,7 @@ var estr = map[Event]string{
 	Write:  "write",
 	Move:   "move",
 }
+
+var ekind = map[Event]Event{
+	Move: Create, // TODO(rjeczalik): Move (fsnotify.Rename) does not work, workaround?
+}


### PR DESCRIPTION
@ppknap syscall.IN_MOVE is bound to Move, but in the previous IN_MOVE was not assigned any action (neither Create nor Delete). It means Move alone does not change anything in the directory tree?
