### PR TITLE
This fixes #23 - We need to distinguish between notify.All and notify.IN_ALL_EVENTS flags

### DIFF
--- a/event.go
+++ b/event.go
@@ -5,6 +5,9 @@ import "strings"
 // Event TODO
 type Event uint32
 
+// All TODO
+const All = Create | Delete | Write | Move
+
 // String implements fmt.Stringer interface.
 func (e Event) String() string {
 	var s []string

--- a/event_fsnotify.go
+++ b/event_fsnotify.go
@@ -5,16 +5,15 @@ package notify
 import fsnotifyv1 "gopkg.in/fsnotify.v1"
 
 // Generic notify events.
-var (
+const (
 	Create = FSN_CREATE
 	Delete = FSN_REMOVE
 	Write  = FSN_WRITE
 	Move   = FSN_RENAME
-	All    = FSN_ALL
 )
 
 // Fsnotify events.
-var (
+const (
 	FSN_CREATE = Event(fsnotifyv1.Create)
 	FSN_REMOVE = Event(fsnotifyv1.Remove)
 	FSN_WRITE  = Event(fsnotifyv1.Write)

--- a/event_linux.go
+++ b/event_linux.go
@@ -4,13 +4,12 @@ package notify
 
 import "syscall"
 
-var (
+const (
 	// TODO(ppknap) : rework these flags.
 	Create = IN_CREATE
 	Delete = IN_DELETE
 	Write  = IN_MODIFY
 	Move   = IN_MOVE
-	All    = Create | Delete | Write | Move
 )
 
 // Inotify events.
@@ -33,10 +32,11 @@ const (
 )
 
 var estr = map[Event]string{
-	Create:           "notify.Create",
-	Delete:           "notify.Delete",
-	Write:            "notify.Wwrite",
-	Move:             "notify.Move",
+	// TODO(pknap) this is currently in progress.
+	//Create:           "notify.Create",
+	//Delete:           "notify.Delete",
+	//Write:            "notify.Wwrite",
+	//Move:             "notify.Move",
 	IN_ACCESS:        "notify.IN_ACCESS",
 	IN_MODIFY:        "notify.IN_MODIFY",
 	IN_ATTRIB:        "notify.IN_ATTRIB",

--- a/event_stub.go
+++ b/event_stub.go
@@ -2,12 +2,11 @@
 
 package notify
 
-var (
+const (
 	Create = EV_STUB_CREATE
 	Delete = EV_STUB_DELETE
 	Write  = EV_STUB_WRITE
 	Move   = EV_STUB_MOVE
-	All    = EV_STUB_ALL
 )
 
 // Events TODO

--- a/watcher_inotify.go
+++ b/watcher_inotify.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!fsnotify
 
 package notify
 


### PR DESCRIPTION
If someone wants to monitor all platform independent events they do this by:

``` go
notify.Watch("/home/pknap/dead_animals_fetish", ch, notify.All)
```

If someone needs to use platform specific events they write:

``` go
notify.Watch("/home/pknap/dead_animals_fetish", ch, notify.IN_ALL_EVENTS)
```

I will be working on this shortly. 
