### PR TITLE
Windows doesn't like Unix-like paths

### DIFF
--- a/test/test.go
+++ b/test/test.go
@@ -53,15 +53,6 @@ func walkfn(w notify.Watcher, fn func(notify.Watcher, string) error) filepath.Wa
 	}
 }
 
-// Join TODO
-func join(base, name string) (p string) {
-	p = filepath.Join(base, filepath.FromSlash(name))
-	if name[len(name)-1] == os.PathSeparator {
-		p = p + sep
-	}
-	return
-}
-
 var eityp = reflect.TypeOf((notify.EventInfo)(nil))
 
 type ei struct {

--- a/test/w.go
+++ b/test/w.go
@@ -94,10 +94,10 @@ func (w w) equal(want, got notify.EventInfo) error {
 		return fmt.Errorf("want EventInfo.Name()=%q to be rooted at %q", gotp,
 			w.path)
 	}
-	// Strip the temp path from the event's origin and convert to slashes.
-	gotp = filepath.ToSlash(gotp[len(w.path)+1:])
+	// Strip the temp path from the event's origin.
+	gotp = gotp[len(w.path)+1:]
 	// Strip trailing slash from expected path.
-	if n := len(wantp) - 1; wantp[n] == '/' {
+	if n := len(wantp) - 1; wantp[n] == os.PathSeparator {
 		wantp = wantp[:n]
 	}
 	// Take into account wantb, gotb (not taken because of fsnotify for delete).
@@ -115,7 +115,7 @@ func (w w) exec(ei notify.EventInfo) error {
 	if !ok {
 		return fmt.Errorf("unexpected fixture failure: invalid Event=%v", ei.Event())
 	}
-	if err := fn(join(w.path, ei.Name())); err != nil {
+	if err := fn(filepath.Join(w.path, filepath.FromSlash(ei.Name()))); err != nil {
 		return fmt.Errorf("want err=nil; got %v (ei=%+v)", err, ei)
 	}
 	return nil


### PR DESCRIPTION
First, i wanted to fix this:

```
--- FAIL: TestWatcherBasic (0.09 seconds)
        w.go:194: want EventInfo{Event: notify.Create, Name: github.com\rjeczalik\fs\fs_test.go, IsDir: false}; got EventInfo{Event: notify.Create, Name: github.com/rjeczalik/fs/fs_test.go, IsDir: false}
```

But then, it turned out that I have to do something with "join" func:

```
--- FAIL: TestWatcherBasic (0.08 seconds)
        w.go:193: want err=nil; got open C:\Users\Pawel\AppData\Local\Temp\notify225430075\github.com\rjeczalik\fs\binfs\: The filename, directory name, or volume label syntax is incorrect. (ei={p:github.com\rjeczalik\fs\binfs\ f:Watch i:1 e:4096 b:false})
```
