### PR TITLE
Fix too excessive sed rewrite (use gofmt/eg!)

### DIFF
--- a/event.go
+++ b/event.go
@@ -41,15 +41,17 @@ func (e Event) String() string {
 
 // EventInfo TODO
 type EventInfo interface {
-	Event() Event     // TODO
-	FileName() string // TODO
-	IsDir() bool      // TODO(rjeczalik): Move to WatchInfo?
-	String() string   // TODO
-	Sys() interface{} // TODO
+	Event() Event
+	Path() string // always clean and absolute
+	IsDir() bool  // TODO(rjeczalik): Remove?
+	String() string
+	Sys() interface{}
 }
 
 // String implements EventInfo interface.
-func (e *event) String() string { return e.Event().String() + `, "` + e.FileName() + `"` }
+func (e *event) String() string {
+	return e.Event().String() + `, "` + e.Path() + `"`
+}
 
 // Kind gives generic event type of the EventInfo.Event(). The purpose is to
 // hint the notify runtime whether the event created a file or directory or it

--- a/event_fsnotify.go
+++ b/event_fsnotify.go
@@ -37,7 +37,7 @@ type event struct {
 }
 
 func (e event) Event() Event     { return e.ev }
-func (e event) FileName() string { return e.name }
+func (e event) Path() string     { return e.name }
 func (e event) IsDir() bool      { return e.isdir }
 func (e event) Sys() interface{} { return nil } // no-one cares about fsnotify.Event
 

--- a/event_inotify.go
+++ b/event_inotify.go
@@ -73,6 +73,6 @@ type event struct {
 }
 
 func (e *event) Event() Event     { return decodemask(e.impl.mask, e.sys.Mask) }
-func (e *event) FileName() string { return e.impl.name }
+func (e *event) Path() string     { return e.impl.name }
 func (e *event) IsDir() bool      { return e.sys.Mask&syscall.IN_ISDIR != 0 }
 func (e *event) Sys() interface{} { return e.sys }

--- a/event_kqueue.go
+++ b/event_kqueue.go
@@ -67,8 +67,8 @@ type event struct {
 // Event returns type of a reported event.
 func (e *event) Event() Event { return e.e }
 
-// FileName returns path to file/directory for which event is reported.
-func (e *event) FileName() string { return e.p }
+// Path returns path to file/directory for which event is reported.
+func (e *event) Path() string { return e.p }
 
 // IsDir returns a boolean indicating if event is reported for a directory.
 func (e *event) IsDir() bool { return e.dir }

--- a/event_windows.go
+++ b/event_windows.go
@@ -64,6 +64,6 @@ type event struct {
 }
 
 func (e *event) Event() Event     { return e.e }
-func (e *event) FileName() string { return filepath.Join(syscall.UTF16ToString(e.pathw), e.name) }
+func (e *event) Path() string     { return filepath.Join(syscall.UTF16ToString(e.pathw), e.name) }
 func (e *event) IsDir() bool      { return e.isdir }
 func (e *event) Sys() interface{} { return nil }

--- a/runtime.go
+++ b/runtime.go
@@ -197,7 +197,7 @@ func (r *Runtime) loop() {
 }
 
 func (r *Runtime) dispatch(ei EventInfo) {
-	parent, name, err := r.buildpath(ei.FileName())
+	parent, name, err := r.buildpath(ei.Path())
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/test/runtime.go
+++ b/test/runtime.go
@@ -105,7 +105,7 @@ type Event struct {
 
 // Event implements notify.EventInfo interface.
 func (e Event) Event() notify.Event { return e.E }
-func (e Event) FileName() string    { return e.P }
+func (e Event) Path() string        { return e.P }
 func (e Event) IsDir() bool         { return isDir(e.P) }
 func (e Event) String() string      { return e.E.String() + " - " + e.P }
 func (e Event) Sys() interface{}    { return nil }
@@ -220,7 +220,7 @@ func str(ei notify.EventInfo) string {
 	if ei == nil {
 		return "<nil>"
 	}
-	return fmt.Sprintf("{Name()=%q, Event()=%v, IsDir()=%v}", ei.FileName(), ei.Event(),
+	return fmt.Sprintf("{Name()=%q, Event()=%v, IsDir()=%v}", ei.Path(), ei.Event(),
 		ei.IsDir())
 }
 
@@ -228,7 +228,7 @@ func equal(want, got notify.EventInfo) error {
 	if (want == nil && got != nil) || (want != nil && got == nil) {
 		return fmt.Errorf("want EventInfo=%s; got %s", str(want), str(got))
 	}
-	if want.FileName() != got.FileName() || want.Event() != got.Event() || want.IsDir() != got.IsDir() {
+	if want.Path() != got.Path() || want.Event() != got.Event() || want.IsDir() != got.IsDir() {
 		return fmt.Errorf("want EventInfo=%s; got %s", str(want), str(got))
 	}
 	return nil

--- a/test/test.go
+++ b/test/test.go
@@ -110,7 +110,7 @@ func EI(args ...interface{}) notify.EventInfo {
 		case string:
 			e.p = filepath.FromSlash(v)
 		case notify.EventInfo:
-			e.p, e.e, e.b = v.FileName(), v.Event(), v.IsDir()
+			e.p, e.e, e.b = v.Path(), v.Event(), v.IsDir()
 			if i, ok := v.(Indexer); ok {
 				e.i = i.Index()
 			}
@@ -136,7 +136,7 @@ func EI(args ...interface{}) notify.EventInfo {
 
 // Implements notify.EventInfo interface.
 func (e ei) Event() notify.Event { return e.e }
-func (e ei) FileName() string    { return e.p }
+func (e ei) Path() string        { return e.p }
 func (e ei) IsDir() bool         { return e.b }
 func (e ei) String() string      { return e.e.String() + " - " + e.p }
 func (e ei) Sys() interface{}    { return e.f }

--- a/test/watcher.go
+++ b/test/watcher.go
@@ -88,8 +88,8 @@ func W(t *testing.T, actions Actions) *w {
 }
 
 func (w w) equal(want, got notify.EventInfo) error {
-	wante, wantp, wantb := want.Event(), want.FileName(), want.IsDir()
-	gote, gotp, gotb := got.Event(), got.FileName(), got.IsDir()
+	wante, wantp, wantb := want.Event(), want.Path(), want.IsDir()
+	gote, gotp, gotb := got.Event(), got.Path(), got.IsDir()
 	if !strings.HasPrefix(gotp, w.path) {
 		return fmt.Errorf("want EventInfo.FileName()=%q to be rooted at %q", gotp,
 			w.path)
@@ -115,7 +115,7 @@ func (w w) exec(ei notify.EventInfo) error {
 	if !ok {
 		return fmt.Errorf("unexpected fixture failure: invalid Event=%v", ei.Event())
 	}
-	if err := fn(filepath.Join(w.path, filepath.FromSlash(ei.FileName()))); err != nil {
+	if err := fn(filepath.Join(w.path, filepath.FromSlash(ei.Path()))); err != nil {
 		return fmt.Errorf("want err=nil; got %v (ei=%+v)", err, ei)
 	}
 	return nil

--- a/watcher_kqueue.go
+++ b/watcher_kqueue.go
@@ -125,7 +125,7 @@ func (k *kqueue) monitor() {
 				}
 				if (Event(kevn[0].Fflags) & NOTE_WRITE) != 0 {
 					if err := k.walk(w.p, func(fi os.FileInfo) error {
-						p := filepath.Join(w.p, fi.FileName())
+						p := filepath.Join(w.p, fi.Name())
 						if err := k.watch(p, w.eDir, false, fi.IsDir()); err != nil {
 							if err != errNoNewWatch {
 								// TODO: pass error via chan because state of monitoring is
@@ -214,7 +214,7 @@ func (k *kqueue) Watch(p string, e Event) error {
 	}
 	if dir {
 		if err := k.walk(p, func(fi os.FileInfo) (err error) {
-			if err = k.watch(filepath.Join(p, fi.FileName()),
+			if err = k.watch(filepath.Join(p, fi.Name()),
 				e, false, fi.IsDir()); err != nil {
 				if err != errNoNewWatch {
 					return
@@ -318,7 +318,7 @@ func (k *kqueue) Unwatch(p string) error {
 	if dir {
 		if err = k.walk(p, func(fi os.FileInfo) error {
 			if !fi.IsDir() {
-				return k.unwatch(filepath.Join(p, fi.FileName()), false)
+				return k.unwatch(filepath.Join(p, fi.Name()), false)
 			}
 			return nil
 		}); err != nil {

--- a/watcher_windows.go
+++ b/watcher_windows.go
@@ -261,7 +261,7 @@ func (w *watcher) loop() {
 			for {
 				raw := (*syscall.FileNotifyInformation)(
 					unsafe.Pointer(&overEx.parent.buffer[currOffset]))
-				buf := (*[syscall.MAX_PATH]uint16)(unsafe.Pointer(&raw.FileName))
+				buf := (*[syscall.MAX_PATH]uint16)(unsafe.Pointer(&raw.Path))
 				name := syscall.UTF16ToString(buf[:raw.FileNameLength/2])
 				es = append(es, &event{
 					pathw:  overEx.parent.pathw,


### PR DESCRIPTION
Took opportunity and renamed FileName -> Path (the returned string is
an absolute and clean path, FileName gives impression of a base name)
