### PR TITLE
Run Travis against Go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
- - 1.5.2
+ - 1.5.3
+ - 1.6rc2
 
 os:
  - linux
@@ -10,7 +11,7 @@ os:
 matrix:
   include:
    - os: osx
-     go: 1.5.2
+     go: 1.5.3
      env:
       - GOFLAGS="-tags kqueue"
 


### PR DESCRIPTION
#90

kqueue works fine, so I didn't add it for now.

It may be worth adding GODEBUG=cgocheck=2 too? Much like using -race in tests.