### PR TITLE
include node name in error when traversing fails

### DIFF
--- a/node.go
+++ b/node.go
@@ -6,6 +6,7 @@ package notify
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -70,7 +71,7 @@ Traverse:
 		case errSkip:
 			continue Traverse
 		default:
-			return err
+			return fmt.Errorf("error while traversing %q: %v", nd.Name, err)
 		}
 		// TODO(rjeczalik): tolerate open failures - add failed names to
 		// AddDirError and notify users which names are not added to the tree.


### PR DESCRIPTION
This PR is originally by mnagel to zillode/notify:

> I use Syncthing to recursively watch my whole `$HOME`.
> It fails on the FUSE mount `.gvfs` and this took me *muuuch* to long to figure out.
> With this change it is much more easy to debug such issues.