### PR TITLE
Add option to ignore paths when setting watches.

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -61,7 +61,16 @@ var defaultTree = newTree()
 // e.g. use persistant paths like %userprofile% or watch additionally parent
 // directory of a recursive watchpoint in order to receive delete events for it.
 func Watch(path string, c chan<- EventInfo, events ...Event) error {
-	return defaultTree.Watch(path, c, events...)
+	return defaultTree.Watch(path, c, nil, events...)
+}
+
+// This function works the same way as Watch. In addition it does not watch
+// files or directories based on the return value of the argument function
+// doNotWatch. Given a path as argument doNotWatch should return true if the
+// file or directory should not be watched.
+func WatchWithIgnoring(path string, c chan<- EventInfo,
+	doNotWatch func(string) bool, events ...Event) error {
+	return defaultTree.Watch(path, c, doNotWatch, events...)
 }
 
 // Stop removes all watchpoints registered for c. All underlying watches are

--- a/testing_test.go
+++ b/testing_test.go
@@ -768,17 +768,21 @@ func (n *N) Close() error {
 	return nil
 }
 
+func dummyDoNotWatch(path string) bool {
+	return false
+}
+
 func (n *N) Watch(path string, c chan<- EventInfo, events ...Event) {
 	UpdateWait() // we need to wait on Windows because of its asynchronous watcher.
 	path = filepath.Join(n.w.root, path)
-	if err := n.tree.Watch(path, c, events...); err != nil {
+	if err := n.tree.Watch(path, c, dummyDoNotWatch, events...); err != nil {
 		n.t.Errorf("Watch(%s, %p, %v)=%v", path, c, events, err)
 	}
 }
 
 func (n *N) WatchErr(path string, c chan<- EventInfo, err error, events ...Event) {
 	path = filepath.Join(n.w.root, path)
-	switch e := n.tree.Watch(path, c, events...); {
+	switch e := n.tree.Watch(path, c, dummyDoNotWatch, events...); {
 	case err == nil && e == nil:
 		n.t.Errorf("Watch(%s, %p, %v)=nil", path, c, events)
 	case err != nil && e != err:

--- a/tree.go
+++ b/tree.go
@@ -7,7 +7,7 @@ package notify
 const buffer = 128
 
 type tree interface {
-	Watch(string, chan<- EventInfo, ...Event) error
+	Watch(string, chan<- EventInfo, func(string) bool, ...Event) error
 	Stop(chan<- EventInfo)
 	Close() error
 }

--- a/tree_nonrecursive.go
+++ b/tree_nonrecursive.go
@@ -93,7 +93,7 @@ func (t *nonrecursiveTree) internal(rec <-chan EventInfo) {
 			t.rw.Unlock()
 			continue
 		}
-		err := nd.Add(ei.Path()).AddDir(t.recFunc(eset))
+		err := nd.Add(ei.Path()).AddDir(t.recFunc(eset, nil))
 		t.rw.Unlock()
 		if err != nil {
 			dbgprintf("internal(%p) error: %v", rec, err)
@@ -145,7 +145,8 @@ func (t *nonrecursiveTree) watchDel(nd node, c chan<- EventInfo, e Event) eventD
 }
 
 // Watch TODO(rjeczalik)
-func (t *nonrecursiveTree) Watch(path string, c chan<- EventInfo, events ...Event) error {
+func (t *nonrecursiveTree) Watch(path string, c chan<- EventInfo,
+	doNotWatch func(string) bool, events ...Event) error {
 	if c == nil {
 		panic("notify: Watch using nil channel")
 	}
@@ -162,7 +163,7 @@ func (t *nonrecursiveTree) Watch(path string, c chan<- EventInfo, events ...Even
 	defer t.rw.Unlock()
 	nd := t.root.Add(path)
 	if isrec {
-		return t.watchrec(nd, c, eset|recursive)
+		return t.watchrec(nd, c, eset|recursive, doNotWatch)
 	}
 	return t.watch(nd, c, eset)
 }
@@ -187,8 +188,8 @@ func (t *nonrecursiveTree) watch(nd node, c chan<- EventInfo, e Event) (err erro
 	return nil
 }
 
-func (t *nonrecursiveTree) recFunc(e Event) walkFunc {
-	return func(nd node) error {
+func (t *nonrecursiveTree) recFunc(e Event, doNotWatch func(string) bool) walkFunc {
+	addWatch := func(nd node) (err error) {
 		switch diff := nd.Watch.Add(t.rec, e|omit|Create); {
 		case diff == none:
 		case diff[1] == 0:
@@ -201,9 +202,19 @@ func (t *nonrecursiveTree) recFunc(e Event) walkFunc {
 		}
 		return nil
 	}
+	if doNotWatch != nil {
+		return func(nd node) (err error) {
+			if doNotWatch(nd.Name) {
+				return errSkip
+			}
+			return addWatch(nd)
+		}
+	}
+	return addWatch
 }
 
-func (t *nonrecursiveTree) watchrec(nd node, c chan<- EventInfo, e Event) error {
+func (t *nonrecursiveTree) watchrec(nd node, c chan<- EventInfo, e Event,
+	doNotWatch func(string) bool) error {
 	var traverse func(walkFunc) error
 	// Non-recursive tree listens on Create event for every recursive
 	// watchpoint in order to automagically set a watch for every
@@ -225,7 +236,7 @@ func (t *nonrecursiveTree) watchrec(nd node, c chan<- EventInfo, e Event) error 
 	}
 	// TODO(rjeczalik): account every path that failed to be (re)watched
 	// and retry.
-	if err := traverse(t.recFunc(e)); err != nil {
+	if err := traverse(t.recFunc(e, doNotWatch)); err != nil {
 		return err
 	}
 	t.watchAdd(nd, c, e)

--- a/tree_recursive.go
+++ b/tree_recursive.go
@@ -153,7 +153,8 @@ func (t *recursiveTree) dispatch() {
 }
 
 // Watch TODO(rjeczalik)
-func (t *recursiveTree) Watch(path string, c chan<- EventInfo, events ...Event) error {
+func (t *recursiveTree) Watch(path string, c chan<- EventInfo,
+	doNotWatch func(string) bool, events ...Event) error {
 	if c == nil {
 		panic("notify: Watch using nil channel")
 	}


### PR DESCRIPTION
This is a modified version of Zillode/notify#3 and adds (some of) the capability requested in #79. syncthing-inotify uses the mentioned fork with this functionality and it works fine. The main advantage over the status quo (filtering events out after generation) is that this saves watch handles (and is slightly more efficient).

The changes are completely backward compatible. Nothing changes for the existing `Watch` function. The new functionality is included in a new function `WatchWithIgnoring`. This function takes the function variable `doNotWatch` in addition to the usual arguments. This function should return true if given a path (string) that is to be ignored. This is implemented by returning different functions in `recFunc` depending on whether `Watch` (no change) or `WatchWithIgnoring` (check doNotWatch at beginning) is used.

I would appreciate your feedback.
