### PR TITLE
Improve documentation (comments) about events and polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Filesystem event notification library on steroids. (under active development)
 - [github.com/rjeczalik/cmd/notify](https://godoc.org/github.com/rjeczalik/cmd/notify)
 - [github.com/cortesi/devd](https://github.com/cortesi/devd)
 - [github.com/cortesi/modd](https://github.com/cortesi/modd)
-
+- [github.com/syncthing/syncthing-inotify](https://github.com/syncthing/syncthing-inotify)

--- a/doc.go
+++ b/doc.go
@@ -12,11 +12,14 @@
 // source file.
 //
 // On top of filesystem watchers notify maintains a watchpoint tree, which provides
-// strategy for creating and closing filesystem watches and dispatching filesystem
+// a strategy for creating and closing filesystem watches and dispatching filesystem
 // events to user channels.
 //
 // An event set is just an event list joint using bitwise OR operator
 // into a single event value.
+// Both the platform-independent (see Constants) and specific events can be used.
+// Refer to the event_*.go source files for information about the available
+// events.
 //
 // A filesystem watch or just a watch is platform-specific entity which represents
 // a single path registered for notifications for specific event set. Setting a watch
@@ -35,6 +38,6 @@
 // A watchpoint is a list of user channel and event set pairs for particular
 // path (watchpoint tree's node). A single watchpoint can contain multiple
 // different user channels registered to listen for one or more events. A single
-// user channel can be registered in one or more watchpoints, recurisve and
+// user channel can be registered in one or more watchpoints, recursive and
 // non-recursive ones as well.
 package notify

--- a/event_readdcw.go
+++ b/event_readdcw.go
@@ -27,7 +27,11 @@ const (
 	dirmarker
 )
 
-// ReadDirectoryChangesW filters.
+// ReadDirectoryChangesW filters
+// On Windows the following events can be passed to Watch. A different set of
+// events (see actions below) are received on the channel passed to Watch.
+// For more information refer to
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa365465(v=vs.85).aspx
 const (
 	FileNotifyChangeFileName   = Event(syscall.FILE_NOTIFY_CHANGE_FILE_NAME)
 	FileNotifyChangeDirName    = Event(syscall.FILE_NOTIFY_CHANGE_DIR_NAME)
@@ -48,7 +52,13 @@ const (
 // this flag should be declared in: http://golang.org/src/pkg/syscall/ztypes_windows.go
 const syscallFileNotifyChangeSecurity = 0x00000100
 
-// ReadDirectoryChangesW actions.
+// ReadDirectoryChangesW actions
+// The following events are returned on the channel passed to Watch, but cannot
+// be passed to Watch itself (see filters above). You can find a table showing
+// the relation between actions and filteres at
+// https://github.com/rjeczalik/notify/issues/10#issuecomment-66179535
+// The msdn documentation on actions is part of
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa364391(v=vs.85).aspx
 const (
 	FileActionAdded          = Event(syscall.FILE_ACTION_ADDED) << 12
 	FileActionRemoved        = Event(syscall.FILE_ACTION_REMOVED) << 12


### PR DESCRIPTION
This is the result of the discussions in #117.
It adds some information about how events work for readdcw (difference between filters and actions). Additionally there is a sentence in the "main documentation" refering to the events_*.go files for information about available events and very few typo/language errors I came across (I hope I didn't add any myself).

Edit: And add syncthing-inotify to the programs using notify.