### PR TITLE
Switch to InotifyInit1 syscall for mips64/etc

### DIFF
--- a/watcher_inotify.go
+++ b/watcher_inotify.go
@@ -120,7 +120,7 @@ func (i *inotify) lazyinit() error {
 		i.Lock()
 		defer i.Unlock()
 		if atomic.LoadInt32(&i.fd) == invalidDescriptor {
-			fd, err := unix.InotifyInit()
+			fd, err := unix.InotifyInit1(unix.IN_CLOEXEC)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
The InotifyInit syscall doesn't exist on all architectures, but
InotifyInit1 does.  In the kernel implementation, inotify_init is just a
wrapper around inotify_init1 and passes in zero for the only parameter
which is a flags field.