### PR TITLE
readdcw: Check state on every loop iteration

### DIFF
--- a/watcher_readdcw.go
+++ b/watcher_readdcw.go
@@ -337,14 +337,13 @@ func (r *readdcw) loop() {
 			continue
 		}
 		overEx := (*overlappedEx)(unsafe.Pointer(overlapped))
-		if n == 0 {
-			r.loopstate(overEx)
-		} else {
+		if n != 0 {
 			r.loopevent(n, overEx)
 			if err = overEx.parent.readDirChanges(); err != nil {
 				// TODO: error handling
 			}
 		}
+		r.loopstate(overEx)
 	}
 }
 

--- a/watcher_readdcw.go
+++ b/watcher_readdcw.go
@@ -284,16 +284,14 @@ func (r *readdcw) watch(path string, event Event, recursive bool) (err error) {
 			return
 		}
 		r.Lock()
+		defer r.Unlock()
 		if wd, ok = r.m[path]; ok {
-			r.Unlock()
 			return
 		}
 		if wd, err = newWatched(r.cph, uint32(event), recursive, path); err != nil {
-			r.Unlock()
 			return
 		}
 		r.m[path] = wd
-		r.Unlock()
 	}
 	return nil
 }
@@ -349,6 +347,8 @@ func (r *readdcw) loop() {
 
 // TODO(pknap) : doc
 func (r *readdcw) loopstate(overEx *overlappedEx) {
+	r.Lock()
+	defer r.Unlock()
 	filter := atomic.LoadUint32(&overEx.parent.parent.filter)
 	if filter&onlyMachineStates == 0 {
 		return
@@ -356,13 +356,9 @@ func (r *readdcw) loopstate(overEx *overlappedEx) {
 	if overEx.parent.parent.count--; overEx.parent.parent.count == 0 {
 		switch filter & onlyMachineStates {
 		case stateRewatch:
-			r.Lock()
 			overEx.parent.parent.recreate(r.cph)
-			r.Unlock()
 		case stateUnwatch:
-			r.Lock()
 			delete(r.m, syscall.UTF16ToString(overEx.parent.pathw))
-			r.Unlock()
 		case stateCPClose:
 		default:
 			panic(`notify: windows loopstate logic error`)
@@ -449,8 +445,8 @@ func (r *readdcw) rewatch(path string, oldevent, newevent uint32, recursive bool
 	}
 	var wd *watched
 	r.Lock()
+	defer r.Unlock()
 	if wd, err = r.nonStateWatched(path); err != nil {
-		r.Unlock()
 		return
 	}
 	if wd.filter&(onlyNotifyChanges|onlyNGlobalEvents) != oldevent {
@@ -461,10 +457,8 @@ func (r *readdcw) rewatch(path string, oldevent, newevent uint32, recursive bool
 	if err = wd.closeHandle(); err != nil {
 		wd.filter = oldevent
 		wd.recursive = recursive
-		r.Unlock()
 		return
 	}
-	r.Unlock()
 	return
 }
 
@@ -496,17 +490,15 @@ func (r *readdcw) RecursiveUnwatch(path string) error {
 func (r *readdcw) unwatch(path string) (err error) {
 	var wd *watched
 	r.Lock()
+	defer r.Unlock()
 	if wd, err = r.nonStateWatched(path); err != nil {
-		r.Unlock()
 		return
 	}
 	wd.filter |= stateUnwatch
 	if err = wd.closeHandle(); err != nil {
 		wd.filter &^= stateUnwatch
-		r.Unlock()
 		return
 	}
-	r.Unlock()
 	return
 }
 


### PR DESCRIPTION
An incoming event can contain an actual change (`n != 0`) and at the same time have a changed state (`filter&onlyMachineStates == 0`). If this changed state is not handled, it wont be as it will not trigger another iteration (`syscall.GetQueuedCompletionStatus` doesn't return again).

Scenario:  
`Stop` a watch at the same time as an event is created (in original case: file removed). Then `Watch` it again. After that no more events are generated and calling `Stop` again logs an error.

I added some debug statements to the tests where this error occurs, they should be self-explanatory (tell me if not or if I should add them to the PR). In the following log the first time after `Stop` the change in state is picked up, the second time it is not and then no more events are registered even though files are created. The third time `Stop` itself reports an error.

```
2017/08/27 14:35:08.535964 [D] Stop(0xc04203aea0) error: <nil>
2017/08/27 14:35:08.535964 [D] loopstate: stateUnwatch
2017/08/27 14:35:09.950001 [D] dispatching notify.FileActionRenamedOldName on "C:\\Temp\\syncthing-d3d5715d\\src\\github.com\\syncthing\\syncthing\\lib\\fswatcher\\temporary_test_fswatcher\\oldfile"
2017/08/27 14:35:09.950001 [D] dispatching notify.FileActionRenamedNewName on "C:\\Temp\\syncthing-d3d5715d\\src\\github.com\\syncthing\\syncthing\\lib\\fswatcher\\temporary_test_fswatcher\\newfile"
2017/08/27 14:35:13.651173 [D] Stop(0xc04203b500) error: <nil>
2017/08/27 14:35:13.653176 [D] dispatching notify.FileActionRemoved on "C:\\Temp\\syncthing-d3d5715d\\src\\github.com\\syncthing\\syncthing\\lib\\fswatcher\\temporary_test_fswatcher\\newfile"
2017/08/27 14:35:16.366990 [D] Stop(0xc04203b980) error: notify: another re/unwatching operation in progress
```