### PR TITLE
Use log package for timestamps and enable debugging via env var NOTIFY_DEBUG

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -2,10 +2,52 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build !debug
-
 package notify
 
-func dbgprint(...interface{}) {}
+import (
+	"log"
+	"os"
+	"runtime"
+	"strings"
+)
 
-func dbgprintf(string, ...interface{}) {}
+var dbgprint func(...interface{})
+
+var dbgprintf func(string, ...interface{})
+
+var dbgcallstack func(max int) []string
+
+func init() {
+	if _, ok := os.LookupEnv("NOTIFY_DEBUG"); ok || debugTag {
+		log.SetOutput(os.Stdout)
+		log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
+		dbgprint = func(v ...interface{}) {
+			v = append([]interface{}{"[D] "}, v...)
+			log.Println(v...)
+		}
+		dbgprintf = func(format string, v ...interface{}) {
+			format = "[D] " + format
+			log.Printf(format, v...)
+		}
+		dbgcallstack = func(max int) []string {
+			pc, stack := make([]uintptr, max), make([]string, 0, max)
+			runtime.Callers(2, pc)
+			for _, pc := range pc {
+				if f := runtime.FuncForPC(pc); f != nil {
+					fname := f.Name()
+					idx := strings.LastIndex(fname, string(os.PathSeparator))
+					if idx != -1 {
+						stack = append(stack, fname[idx+1:])
+					} else {
+						stack = append(stack, fname)
+					}
+				}
+			}
+			return stack
+		}
+		return
+	}
+	dbgprint = func(v ...interface{}) {}
+	dbgprintf = func(format string, v ...interface{}) {}
+	dbgcallstack = func(max int) []string { return nil }
+}

--- a/debug_nodebug.go
+++ b/debug_nodebug.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build debug
+// +build !debug
 
 package notify
 
-var debugTag bool = true
+var debugTag bool = false

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -8,7 +8,7 @@ package notify
 
 import "testing"
 
-// NOTE Set DEBUG env var for extra debugging info.
+// NOTE Set NOTIFY_DEBUG env var or debug build tag for extra debugging info.
 
 func TestWatcher(t *testing.T) {
 	w := NewWatcherTest(t, "testdata/vfs.txt")


### PR DESCRIPTION
Now you can enable debugging both by debug tag and setting an environment variable. Also the output includes timestamps, which is potentially crucial to debug event based problems.