### PR TITLE
node: Return traverse error as os.PathError

### DIFF
--- a/node.go
+++ b/node.go
@@ -6,7 +6,6 @@ package notify
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -71,7 +70,11 @@ Traverse:
 		case errSkip:
 			continue Traverse
 		default:
-			return fmt.Errorf("error while traversing %q: %v", nd.Name, err)
+			return &os.PathError{
+				Op:   "error while traversing",
+				Path: nd.Name,
+				Err:  err,
+			}
 		}
 		// TODO(rjeczalik): tolerate open failures - add failed names to
 		// AddDirError and notify users which names are not added to the tree.


### PR DESCRIPTION
Missing nodes are already reported as `os.PathError`. This does the same for the error returned when setting up a recursive watch with a non-recursive watcher, i.e. during traversing. The error string is the same as before, so user of this library wont notice the change. This allows to check the underlying error and which path causes the problem. An example of a use case is for Syncthing, where we want to notify the user when the error is due to hitting the inotify handler limit.