### PR TITLE
Handle pointers that are now integers in Go 1.10 (fixes #135)

### DIFF
--- a/watcher_fsevents_cgo.go
+++ b/watcher_fsevents_cgo.go
@@ -48,7 +48,7 @@ var wg sync.WaitGroup      // used to wait until the runloop starts
 // started and is ready via the wg. It also serves purpose of a dummy source,
 // thanks to it the runloop does not return as it also has at least one source
 // registered.
-var source = C.CFRunLoopSourceCreate(nil, 0, &C.CFRunLoopSourceContext{
+var source = C.CFRunLoopSourceCreate(refZero, 0, &C.CFRunLoopSourceContext{
 	perform: (C.CFRunLoopPerformCallBack)(C.gosource),
 })
 
@@ -159,8 +159,8 @@ func (s *stream) Start() error {
 		return nil
 	}
 	wg.Wait()
-	p := C.CFStringCreateWithCStringNoCopy(nil, C.CString(s.path), C.kCFStringEncodingUTF8, nil)
-	path := C.CFArrayCreate(nil, (*unsafe.Pointer)(unsafe.Pointer(&p)), 1, nil)
+	p := C.CFStringCreateWithCStringNoCopy(refZero, C.CString(s.path), C.kCFStringEncodingUTF8, refZero)
+	path := C.CFArrayCreate(refZero, (*unsafe.Pointer)(unsafe.Pointer(&p)), 1, nil)
 	ctx := C.FSEventStreamContext{}
 	ref := C.EventStreamCreate(&ctx, C.uintptr_t(s.info), path, C.FSEventStreamEventId(atomic.LoadUint64(&since)), latency, flags)
 	if ref == nilstream {

--- a/watcher_fsevents_go1.10.go
+++ b/watcher_fsevents_go1.10.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2017 The Notify Authors. All rights reserved.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+// +build darwin,!kqueue,go1.10
+
+package notify
+
+const refZero = 0

--- a/watcher_fsevents_go1.9.go
+++ b/watcher_fsevents_go1.9.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2017 The Notify Authors. All rights reserved.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+// +build darwin,!kqueue,cgo,!go1.10
+
+package notify
+
+/*
+#include <CoreServices/CoreServices.h>
+*/
+import "C"
+
+var refZero = (*C.struct___CFAllocator)(nil)


### PR DESCRIPTION
The Core Services reference types became integer shaped after being
pointer shaped in Go 1.9. I moved the thing out into a constant zero or
nil variable according to the Go version, in order to avoid duplicating
a bunch of code into separate files.

This is the required fix according to
https://go-review.googlesource.com/c/go/+/66332.

This passes tests with Go 1.9.2. and 1.10beta1.