### PR TITLE
FSEvents: remove time.Sleep call in run loop setup

### DIFF
--- a/watcher_fsevents_cgo.go
+++ b/watcher_fsevents_cgo.go
@@ -29,7 +29,6 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
-	"time"
 	"unsafe"
 )
 
@@ -78,7 +77,6 @@ func init() {
 
 //export gosource
 func gosource(unsafe.Pointer) {
-	time.Sleep(time.Second)
 	wg.Done()
 }
 


### PR DESCRIPTION
According to https://github.com/rjeczalik/notify/pull/140#issuecomment-354991635 the call to sleep was added for debugging.
  