### PR TITLE
travis: run against tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
  - 1.7.5
+ - tip
 
 os:
  - linux
@@ -13,6 +14,8 @@ matrix:
      go: 1.7.5
      env:
       - GOFLAGS="-tags kqueue"
+  allow_failures:
+   - go: tip
 
 env:
   global:


### PR DESCRIPTION
Running against tip in order to allow for noticing any breaking
changes with upcomming Go release.