### PR TITLE
kqueue: Don't panic when an error occurs on init (fixes #149)

### DIFF
--- a/watcher_notimplemented.go
+++ b/watcher_notimplemented.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2014-2018 The Notify Authors. All rights reserved.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+// +build !darwin,!linux,!freebsd,!dragonfly,!netbsd,!openbsd,!windows
+// +build !kqueue,!solaris
+
+package notify
+
+import "errors"
+
+// newWatcher stub.
+func newWatcher(chan<- EventInfo) watcher {
+	return watcherStub{errors.New("notify: not implemented")}
+}

--- a/watcher_stub.go
+++ b/watcher_stub.go
@@ -1,23 +1,13 @@
-// Copyright (c) 2014-2015 The Notify Authors. All rights reserved.
+// Copyright (c) 2014-2018 The Notify Authors. All rights reserved.
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build !darwin,!linux,!freebsd,!dragonfly,!netbsd,!openbsd,!windows
-// +build !kqueue,!solaris
-
 package notify
 
-import "errors"
-
-type stub struct{ error }
-
-// newWatcher stub.
-func newWatcher(chan<- EventInfo) watcher {
-	return stub{errors.New("notify: not implemented")}
-}
+type watcherStub struct{ error }
 
 // Following methods implement notify.watcher interface.
-func (s stub) Watch(string, Event) error          { return s }
-func (s stub) Rewatch(string, Event, Event) error { return s }
-func (s stub) Unwatch(string) (err error)         { return s }
-func (s stub) Close() error                       { return s }
+func (s watcherStub) Watch(string, Event) error          { return s }
+func (s watcherStub) Rewatch(string, Event, Event) error { return s }
+func (s watcherStub) Unwatch(string) (err error)         { return s }
+func (s watcherStub) Close() error                       { return s }

--- a/watcher_trigger.go
+++ b/watcher_trigger.go
@@ -106,7 +106,8 @@ func newWatcher(c chan<- EventInfo) watcher {
 	}
 	t.t = newTrigger(t.pthLkp)
 	if err := t.t.Init(); err != nil {
-		panic(err)
+		t.Close()
+		return watcherStub{fmt.Errorf("failed setting up watcher: %v", err)}
 	}
 	go t.monitor()
 	return t


### PR DESCRIPTION
Instead of panicking, return a stub watcher that returns a sensible error message like the "not implemented" one does.

Another approach was implemented by @calmh, in that the watcher isn't initialized initially but only on first use and the initialization function recovers from panics: https://github.com/syncthing/notify/commit/2556ab349002cb2f9c250783c06b1976fc7d23b4