### PR TITLE
readdcw: close handle during unwatch state

### DIFF
--- a/debug_debug.go
+++ b/debug_debug.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 The Notify Authors. All rights reserved.
+// Copyright (c) 2014-2018 The Notify Authors. All rights reserved.
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
@@ -6,4 +6,4 @@
 
 package notify
 
-var debugTag bool = true
+var debugTag = true

--- a/debug_nodebug.go
+++ b/debug_nodebug.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 The Notify Authors. All rights reserved.
+// Copyright (c) 2014-2018 The Notify Authors. All rights reserved.
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
@@ -6,4 +6,4 @@
 
 package notify
 
-var debugTag bool = false
+var debugTag = false

--- a/watcher_readdcw.go
+++ b/watcher_readdcw.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 The Notify Authors. All rights reserved.
+// Copyright (c) 2014-2018 The Notify Authors. All rights reserved.
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
@@ -22,7 +22,7 @@ import (
 const readBufferSize = 4096
 
 // Since all operations which go through the Windows completion routine are done
-// asynchronously, filter may set one of the constants belor. They were defined
+// asynchronously, filter may set one of the constants below. They were defined
 // in order to distinguish whether current folder should be re-registered in
 // ReadDirectoryChangesW function or some control operations need to be executed.
 const (
@@ -109,8 +109,13 @@ func (g *grip) register(cph syscall.Handle) (err error) {
 // buffer. Directory changes that occur between calls to this function are added
 // to the buffer and then, returned with the next call.
 func (g *grip) readDirChanges() error {
+	handle := syscall.Handle(atomic.LoadUintptr((*uintptr)(&g.handle)))
+	if handle == syscall.InvalidHandle {
+		return nil // Handle was closed.
+	}
+
 	return syscall.ReadDirectoryChanges(
-		g.handle,
+		handle,
 		&g.buffer[0],
 		uint32(unsafe.Sizeof(g.buffer)),
 		g.recursive,
@@ -220,12 +225,27 @@ func (wd *watched) updateGrip(idx int, cph syscall.Handle, reset bool,
 // returned from the operating system kernel.
 func (wd *watched) closeHandle() (err error) {
 	for _, g := range wd.digrip {
-		if g != nil && g.handle != syscall.InvalidHandle {
-			switch suberr := syscall.CloseHandle(g.handle); {
-			case suberr == nil:
-				g.handle = syscall.InvalidHandle
-			case err == nil:
-				err = suberr
+		if g == nil {
+			continue
+		}
+
+		for {
+			handle := syscall.Handle(atomic.LoadUintptr((*uintptr)(&g.handle)))
+			if handle == syscall.InvalidHandle {
+				break // Already closed.
+			}
+
+			e := syscall.CloseHandle(g.handle)
+			if e != nil && err == nil {
+				err = e
+			}
+
+			// Set invalid handle even when CloseHandle fails. This will leak
+			// the handle but, since we can't close it anyway, there won't be
+			// any difference.
+			if atomic.CompareAndSwapUintptr((*uintptr)(&g.handle),
+				(uintptr)(handle), (uintptr)(syscall.InvalidHandle)) {
+				break
 			}
 		}
 	}
@@ -272,50 +292,49 @@ func (r *readdcw) RecursiveWatch(path string, event Event) error {
 // watch inserts a directory to the group of watched folders. If watched folder
 // already exists, function tries to rewatch it with new filters(NOT VALID). Moreover,
 // watch starts the main event loop goroutine when called for the first time.
-func (r *readdcw) watch(path string, event Event, recursive bool) (err error) {
+func (r *readdcw) watch(path string, event Event, recursive bool) error {
 	if event&^(All|fileNotifyChangeAll) != 0 {
 		return errors.New("notify: unknown event")
 	}
+
 	r.Lock()
-	wd, ok := r.m[path]
-	r.Unlock()
-	if !ok {
-		if err = r.lazyinit(); err != nil {
-			return
-		}
-		r.Lock()
-		defer r.Unlock()
-		if wd, ok = r.m[path]; ok {
-			dbgprint("watch: exists already")
-			return
-		}
-		if wd, err = newWatched(r.cph, uint32(event), recursive, path); err != nil {
-			return
-		}
-		r.m[path] = wd
-		dbgprint("watch: new watch added")
-	} else {
-		dbgprint("watch: exists already")
+	defer r.Unlock()
+
+	if wd, ok := r.m[path]; ok {
+		dbgprint("watch: already exists")
+		wd.filter &^= stateUnwatch
+		return nil
 	}
+
+	if err := r.lazyinit(); err != nil {
+		return err
+	}
+
+	wd, err := newWatched(r.cph, uint32(event), recursive, path)
+	if err != nil {
+		return err
+	}
+
+	r.m[path] = wd
+	dbgprint("watch: new watch added")
+
 	return nil
 }
 
-// lazyinit creates an I/O completion port and starts the main event processing
-// loop. This method uses Double-Checked Locking optimization.
+// lazyinit creates an I/O completion port and starts the main event loop.
 func (r *readdcw) lazyinit() (err error) {
 	invalid := uintptr(syscall.InvalidHandle)
+
 	if atomic.LoadUintptr((*uintptr)(&r.cph)) == invalid {
-		r.Lock()
-		defer r.Unlock()
-		if atomic.LoadUintptr((*uintptr)(&r.cph)) == invalid {
-			cph := syscall.InvalidHandle
-			if cph, err = syscall.CreateIoCompletionPort(cph, 0, 0, 0); err != nil {
-				return
-			}
-			r.cph, r.start = cph, true
-			go r.loop()
+		cph := syscall.InvalidHandle
+		if cph, err = syscall.CreateIoCompletionPort(cph, 0, 0, 0); err != nil {
+			return
 		}
+
+		r.cph, r.start = cph, true
+		go r.loop()
 	}
+
 	return
 }
 
@@ -364,6 +383,7 @@ func (r *readdcw) loopstate(overEx *overlappedEx) {
 			overEx.parent.parent.recreate(r.cph)
 		case stateUnwatch:
 			dbgprint("loopstate unwatch")
+			overEx.parent.parent.closeHandle()
 			delete(r.m, syscall.UTF16ToString(overEx.parent.pathw))
 		case stateCPClose:
 		default:
@@ -495,27 +515,30 @@ func (r *readdcw) RecursiveUnwatch(path string) error {
 // TODO : pknap
 func (r *readdcw) unwatch(path string) (err error) {
 	var wd *watched
+
 	r.Lock()
 	defer r.Unlock()
 	if wd, err = r.nonStateWatchedLocked(path); err != nil {
 		return
 	}
+
 	wd.filter |= stateUnwatch
-	if err = wd.closeHandle(); err != nil {
-		wd.filter &^= stateUnwatch
-		return
-	}
+	dbgprint("unwatch: set unwatch state")
+
 	if _, attrErr := syscall.GetFileAttributes(&wd.pathw[0]); attrErr != nil {
 		for _, g := range wd.digrip {
-			if g != nil {
-				dbgprint("unwatch: posting")
-				if err = syscall.PostQueuedCompletionStatus(r.cph, 0, 0, (*syscall.Overlapped)(unsafe.Pointer(g.ovlapped))); err != nil {
-					wd.filter &^= stateUnwatch
-					return
-				}
+			if g == nil {
+				continue
+			}
+
+			dbgprint("unwatch: posting")
+			if err = syscall.PostQueuedCompletionStatus(r.cph, 0, 0, (*syscall.Overlapped)(unsafe.Pointer(g.ovlapped))); err != nil {
+				wd.filter &^= stateUnwatch
+				return
 			}
 		}
 	}
+
 	return
 }
 

--- a/watcher_readdcw.go
+++ b/watcher_readdcw.go
@@ -235,7 +235,7 @@ func (wd *watched) closeHandle() (err error) {
 				break // Already closed.
 			}
 
-			e := syscall.CloseHandle(g.handle)
+			e := syscall.CloseHandle(handle)
 			if e != nil && err == nil {
 				err = e
 			}


### PR DESCRIPTION
The `Unwatch` method on Windows is asynchronous. Thus, when calling `Watch`, `Unwatch` and `Watch` on the same path, the `Unwatch` state may happen after the second `Watch` call. This means that second `Watch` will be skipped as already created.

This commit makes second `Watch` call invalidate `Unwatch` state. So `Watch->Unwatch->Watch` calls will be basically a no-op. This doesn't solve all the problems since the second `Watch` might have different events to handle. However, the implementation should use `Rewatch` method instead.

Also, the code fixes a data race that may occur when invalidating grip handle.

Fixes: #150 

/cc @calmh 

<details>
 <summary>Environment and tests</summary>

```
C:\Users\ppknap\go\src\github.com\rjeczalik\notify (issue150 -> origin)
λ ver

Microsoft Windows [Version 6.1.7601]

C:\Users\ppknap\go\src\github.com\rjeczalik\notify (issue150 -> origin)
λ for /l %x in (1, 1, 20) do printf "%x|" && go test -race -run "^TestWatcherUnwatch$"

printf "1|"   && go test -race -run "^TestWatcherUnwatch$"
1|2018/05/01 20:18:39.314451 [D]  watch: new watch added
2018/05/01 20:18:39.403055 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:18:39.404055 [D]  unwatch: set unwatch state
2018/05/01 20:18:39.405055 [D]  watch: already exists
2018/05/01 20:18:39.505061 [D] ExpectAny: i=0
2018/05/01 20:18:39.514061 [D] [FS] os.Create("file")
2018/05/01 20:18:39.519062 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\834339787\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:18:39.569065 [D] ExpectAny: i=1
2018/05/01 20:18:39.570065 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:18:39.571065 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\834339787\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     2.566s

printf "2|"   && go test -race -run "^TestWatcherUnwatch$"
2|2018/05/01 20:18:43.045802 [D]  watch: new watch added
2018/05/01 20:18:43.145407 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:18:43.146407 [D]  unwatch: set unwatch state
2018/05/01 20:18:43.147407 [D]  watch: already exists
2018/05/01 20:18:43.247413 [D] ExpectAny: i=0
2018/05/01 20:18:43.263414 [D] [FS] os.Create("file")
2018/05/01 20:18:43.263414 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\354128847\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:18:43.315615 [D] ExpectAny: i=1
2018/05/01 20:18:43.319615 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:18:43.319615 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\354128847\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     2.807s

printf "3|"   && go test -race -run "^TestWatcherUnwatch$"
3|2018/05/01 20:18:46.885358 [D]  watch: new watch added
2018/05/01 20:18:46.965362 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:18:46.966362 [D]  unwatch: set unwatch state
2018/05/01 20:18:46.966362 [D]  watch: already exists
2018/05/01 20:18:47.066368 [D] ExpectAny: i=0
2018/05/01 20:18:47.082369 [D] [FS] os.Create("file")
2018/05/01 20:18:47.082369 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\879900579\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:18:47.132570 [D] ExpectAny: i=1
2018/05/01 20:18:47.134570 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:18:47.135570 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\879900579\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     2.702s

printf "4|"   && go test -race -run "^TestWatcherUnwatch$"
4|2018/05/01 20:18:51.236710 [D]  watch: new watch added
2018/05/01 20:18:51.302912 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:18:51.303912 [D]  unwatch: set unwatch state
2018/05/01 20:18:51.303912 [D]  watch: already exists
2018/05/01 20:18:51.403917 [D] ExpectAny: i=0
2018/05/01 20:18:51.418918 [D] [FS] os.Create("file")
2018/05/01 20:18:51.418918 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\105574523\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:18:51.469119 [D] ExpectAny: i=1
2018/05/01 20:18:51.470120 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:18:51.470120 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\105574523\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     3.327s

printf "5|"   && go test -race -run "^TestWatcherUnwatch$"
5|2018/05/01 20:18:55.316861 [D]  watch: new watch added
2018/05/01 20:18:55.397865 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:18:55.398865 [D]  unwatch: set unwatch state
2018/05/01 20:18:55.398865 [D]  watch: already exists
2018/05/01 20:18:55.498871 [D] ExpectAny: i=0
2018/05/01 20:18:55.547473 [D] [FS] os.Create("file")
2018/05/01 20:18:55.547473 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\282942499\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:18:55.618675 [D] ExpectAny: i=1
2018/05/01 20:18:55.620676 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:18:55.624676 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\282942499\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     3.166s

printf "6|"   && go test -race -run "^TestWatcherUnwatch$"
6|2018/05/01 20:18:59.388011 [D]  watch: new watch added
2018/05/01 20:18:59.470016 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:18:59.471016 [D]  unwatch: set unwatch state
2018/05/01 20:18:59.471016 [D]  watch: already exists
2018/05/01 20:18:59.571022 [D] ExpectAny: i=0
2018/05/01 20:18:59.586023 [D] [FS] os.Create("file")
2018/05/01 20:18:59.586023 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\673519611\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:18:59.636224 [D] ExpectAny: i=1
2018/05/01 20:18:59.637224 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:18:59.638224 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\673519611\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     3.061s

printf "7|"   && go test -race -run "^TestWatcherUnwatch$"
7|2018/05/01 20:19:03.345759 [D]  watch: new watch added
2018/05/01 20:19:03.418763 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:19:03.419763 [D]  unwatch: set unwatch state
2018/05/01 20:19:03.419763 [D]  watch: already exists
2018/05/01 20:19:03.519769 [D] ExpectAny: i=0
2018/05/01 20:19:03.565970 [D] [FS] os.Create("file")
2018/05/01 20:19:03.565970 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\602055279\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:19:03.616171 [D] ExpectAny: i=1
2018/05/01 20:19:03.617171 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:19:03.617171 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\602055279\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     3.016s

printf "8|"   && go test -race -run "^TestWatcherUnwatch$"
8|2018/05/01 20:19:08.053119 [D]  watch: new watch added
2018/05/01 20:19:08.132722 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:19:08.133722 [D]  unwatch: set unwatch state
2018/05/01 20:19:08.133722 [D]  watch: already exists
2018/05/01 20:19:08.234728 [D] ExpectAny: i=0
2018/05/01 20:19:08.248729 [D] [FS] os.Create("file")
2018/05/01 20:19:08.248729 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\415176055\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:19:08.298930 [D] ExpectAny: i=1
2018/05/01 20:19:08.299930 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:19:08.299930 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\415176055\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     3.582s

printf "9|"   && go test -race -run "^TestWatcherUnwatch$"
9|2018/05/01 20:19:12.316470 [D]  watch: new watch added
2018/05/01 20:19:12.404074 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:19:12.405074 [D]  unwatch: set unwatch state
2018/05/01 20:19:12.405074 [D]  watch: already exists
2018/05/01 20:19:12.505080 [D] ExpectAny: i=0
2018/05/01 20:19:12.512080 [D] [FS] os.Create("file")
2018/05/01 20:19:12.513080 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\029137019\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:19:12.563083 [D] ExpectAny: i=1
2018/05/01 20:19:12.564083 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:19:12.565083 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\029137019\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     3.336s

printf "10|"   && go test -race -run "^TestWatcherUnwatch$"
10|2018/05/01 20:19:16.393220 [D]  watch: new watch added
2018/05/01 20:19:16.483423 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:19:16.484423 [D]  unwatch: set unwatch state
2018/05/01 20:19:16.484423 [D]  watch: already exists
2018/05/01 20:19:16.585429 [D] ExpectAny: i=0
2018/05/01 20:19:16.600430 [D] [FS] os.Create("file")
2018/05/01 20:19:16.600430 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\973170231\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:19:16.650631 [D] ExpectAny: i=1
2018/05/01 20:19:16.651631 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:19:16.652631 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\973170231\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     3.169s

printf "11|"   && go test -race -run "^TestWatcherUnwatch$"
11|2018/05/01 20:19:20.475182 [D]  watch: new watch added
2018/05/01 20:19:20.560786 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:19:20.562786 [D]  unwatch: set unwatch state
2018/05/01 20:19:20.563786 [D]  watch: already exists
2018/05/01 20:19:20.665792 [D] ExpectAny: i=0
2018/05/01 20:19:20.687793 [D] [FS] os.Create("file")
2018/05/01 20:19:20.687793 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\130035915\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:19:20.737994 [D] ExpectAny: i=1
2018/05/01 20:19:20.738994 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:19:20.739994 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\130035915\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     2.932s

printf "12|"   && go test -race -run "^TestWatcherUnwatch$"
12|2018/05/01 20:19:24.604935 [D]  watch: new watch added
2018/05/01 20:19:24.684939 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:19:24.685939 [D]  unwatch: set unwatch state
2018/05/01 20:19:24.685939 [D]  watch: already exists
2018/05/01 20:19:24.785945 [D] ExpectAny: i=0
2018/05/01 20:19:24.800946 [D] [FS] os.Create("file")
2018/05/01 20:19:24.800946 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\116743847\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:19:24.851147 [D] ExpectAny: i=1
2018/05/01 20:19:24.852147 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:19:24.852147 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\116743847\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     3.191s

printf "13|"   && go test -race -run "^TestWatcherUnwatch$"
13|2018/05/01 20:19:28.794088 [D]  watch: new watch added
2018/05/01 20:19:28.880093 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:19:28.881093 [D]  unwatch: set unwatch state
2018/05/01 20:19:28.882093 [D]  watch: already exists
2018/05/01 20:19:28.982099 [D] ExpectAny: i=0
2018/05/01 20:19:28.993099 [D] [FS] os.Create("file")
2018/05/01 20:19:28.994099 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\272474495\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:19:29.044102 [D] ExpectAny: i=1
2018/05/01 20:19:29.045102 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:19:29.046102 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\272474495\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     3.210s

printf "14|"   && go test -race -run "^TestWatcherUnwatch$"
14|2018/05/01 20:19:32.757043 [D]  watch: new watch added
2018/05/01 20:19:32.858648 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:19:32.858648 [D]  unwatch: set unwatch state
2018/05/01 20:19:32.859648 [D]  watch: already exists
2018/05/01 20:19:32.959653 [D] ExpectAny: i=0
2018/05/01 20:19:32.990254 [D] [FS] os.Create("file")
2018/05/01 20:19:32.990254 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\695621655\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:19:33.040455 [D] ExpectAny: i=1
2018/05/01 20:19:33.042456 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:19:33.043456 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\695621655\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     2.973s

printf "15|"   && go test -race -run "^TestWatcherUnwatch$"
15|2018/05/01 20:19:37.467790 [D]  watch: new watch added
2018/05/01 20:19:37.533992 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:19:37.534992 [D]  unwatch: set unwatch state
2018/05/01 20:19:37.534992 [D]  watch: already exists
2018/05/01 20:19:37.635998 [D] ExpectAny: i=0
2018/05/01 20:19:37.650999 [D] [FS] os.Create("file")
2018/05/01 20:19:37.650999 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\427174227\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:19:37.701200 [D] ExpectAny: i=1
2018/05/01 20:19:37.702200 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:19:37.702200 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\427174227\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     3.693s

printf "16|"   && go test -race -run "^TestWatcherUnwatch$"
16|2018/05/01 20:19:41.750345 [D]  watch: new watch added
2018/05/01 20:19:41.837548 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:19:41.838548 [D]  unwatch: set unwatch state
2018/05/01 20:19:41.838548 [D]  watch: already exists
2018/05/01 20:19:41.938554 [D] ExpectAny: i=0
2018/05/01 20:19:42.000355 [D] [FS] os.Create("file")
2018/05/01 20:19:42.000355 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\844537143\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:19:42.050556 [D] ExpectAny: i=1
2018/05/01 20:19:42.051556 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:19:42.051556 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\844537143\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     3.548s

printf "17|"   && go test -race -run "^TestWatcherUnwatch$"
17|2018/05/01 20:19:45.748897 [D]  watch: new watch added
2018/05/01 20:19:45.833501 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:19:45.834501 [D]  unwatch: set unwatch state
2018/05/01 20:19:45.834501 [D]  watch: already exists
2018/05/01 20:19:45.934507 [D] ExpectAny: i=0
2018/05/01 20:19:46.000308 [D] [FS] os.Create("file")
2018/05/01 20:19:46.000308 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\102646687\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:19:46.050509 [D] ExpectAny: i=1
2018/05/01 20:19:46.051509 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:19:46.051509 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\102646687\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     2.870s

printf "18|"   && go test -race -run "^TestWatcherUnwatch$"
18|2018/05/01 20:19:49.784046 [D]  watch: new watch added
2018/05/01 20:19:49.858050 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:19:49.859050 [D]  unwatch: set unwatch state
2018/05/01 20:19:49.859050 [D]  watch: already exists
2018/05/01 20:19:49.959056 [D] ExpectAny: i=0
2018/05/01 20:19:49.973056 [D] [FS] os.Create("file")
2018/05/01 20:19:49.973056 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\944512547\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:19:50.023257 [D] ExpectAny: i=1
2018/05/01 20:19:50.024258 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:19:50.024258 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\944512547\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     3.048s

printf "19|"   && go test -race -run "^TestWatcherUnwatch$"
19|2018/05/01 20:19:54.419599 [D]  watch: new watch added
2018/05/01 20:19:54.508802 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:19:54.509802 [D]  unwatch: set unwatch state
2018/05/01 20:19:54.509802 [D]  watch: already exists
2018/05/01 20:19:54.609808 [D] ExpectAny: i=0
2018/05/01 20:19:54.624809 [D] [FS] os.Create("file")
2018/05/01 20:19:54.624809 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\353541443\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:19:54.675010 [D] ExpectAny: i=1
2018/05/01 20:19:54.676010 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:19:54.676010 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\353541443\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     3.616s

printf "20|"   && go test -race -run "^TestWatcherUnwatch$"
20|2018/05/01 20:19:58.776551 [D]  watch: new watch added
2018/05/01 20:19:58.859353 [D] [FS] os.Remove("src/github.com/ppknap/link/test/test_circular_calls.cpp")
2018/05/01 20:19:58.859353 [D]  unwatch: set unwatch state
2018/05/01 20:19:58.859353 [D]  watch: already exists
2018/05/01 20:19:58.960358 [D] ExpectAny: i=0
2018/05/01 20:19:58.973359 [D] [FS] os.Create("file")
2018/05/01 20:19:58.974359 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\713759767\\file", event=notify.Create, sys=1 (i=0)
2018/05/01 20:19:59.024362 [D] ExpectAny: i=1
2018/05/01 20:19:59.025362 [D] [FS] os.Mkdir("dir/")
2018/05/01 20:19:59.025362 [D] received: path="C:\\Users\\ppknap\\go\\src\\github.com\\rjeczalik\\notify\\testdata\\713759767\\dir", event=notify.Create, sys=2 (i=1)
PASS
ok      github.com/rjeczalik/notify     3.410s

C:\Users\ppknap\go\src\github.com\rjeczalik\notify (issue150 -> origin)
λ set NOTIFY_DEBUG=

C:\Users\ppknap\go\src\github.com\rjeczalik\notify (issue150 -> origin)
λ for /l %x in (1, 1, 20) do printf "%x|" && go test -race

printf "1|"   && go test -race
1|PASS
ok      github.com/rjeczalik/notify     42.855s

printf "2|"   && go test -race
2|PASS
ok      github.com/rjeczalik/notify     43.894s

printf "3|"   && go test -race
3|PASS
ok      github.com/rjeczalik/notify     44.795s

printf "4|"   && go test -race
4|PASS
ok      github.com/rjeczalik/notify     50.183s

printf "5|"   && go test -race
5|PASS
ok      github.com/rjeczalik/notify     49.517s

printf "6|"   && go test -race
6|PASS
ok      github.com/rjeczalik/notify     52.453s

printf "7|"   && go test -race
7|PASS
ok      github.com/rjeczalik/notify     52.588s

printf "8|"   && go test -race
8|PASS
ok      github.com/rjeczalik/notify     54.950s

printf "9|"   && go test -race
9|PASS
ok      github.com/rjeczalik/notify     52.398s

printf "10|"   && go test -race
10|PASS
ok      github.com/rjeczalik/notify     52.055s

printf "11|"   && go test -race
11|PASS
ok      github.com/rjeczalik/notify     52.835s

printf "12|"   && go test -race
12|PASS
ok      github.com/rjeczalik/notify     49.752s

printf "13|"   && go test -race
13|PASS
ok      github.com/rjeczalik/notify     44.863s

printf "14|"   && go test -race
14|PASS
ok      github.com/rjeczalik/notify     46.374s

printf "15|"   && go test -race
15|PASS
ok      github.com/rjeczalik/notify     47.617s

printf "16|"   && go test -race
16|PASS
ok      github.com/rjeczalik/notify     50.219s

printf "17|"   && go test -race
17|PASS
ok      github.com/rjeczalik/notify     53.130s

printf "18|"   && go test -race
18|PASS
ok      github.com/rjeczalik/notify     48.369s

printf "19|"   && go test -race
19|PASS
ok      github.com/rjeczalik/notify     45.636s

printf "20|"   && go test -race
20|PASS
ok      github.com/rjeczalik/notify     47.113s
```

</details>



