### PR TITLE
fsevents: Prevent nil deref

### DIFF
--- a/watcher_fsevents_cgo.go
+++ b/watcher_fsevents_cgo.go
@@ -90,6 +90,10 @@ func gostream(_, info uintptr, n C.size_t, paths, flags, ids uintptr) {
 	if n == 0 {
 		return
 	}
+	fn := streamFuncs.get(info)
+	if fn == nil {
+		return
+	}
 	ev := make([]FSEvent, 0, int(n))
 	for i := uintptr(0); i < uintptr(n); i++ {
 		switch flags := *(*uint32)(unsafe.Pointer((flags + i*offflag))); {
@@ -104,7 +108,7 @@ func gostream(_, info uintptr, n C.size_t, paths, flags, ids uintptr) {
 		}
 
 	}
-	streamFuncs.get(info)(ev)
+	fn(ev)
 }
 
 // StreamFunc is a callback called when stream receives file events.


### PR DESCRIPTION
Since using notify in Syncthing the following panic occurs randomly (see syncthing/syncthing#4854):

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x417b012]

goroutine 19 [running, locked to thread]:
github.com/syncthing/syncthing/vendor/github.com/syncthing/notify.gostream(0x6b00c30, 0x4, 0x11, 0x6900ef0, 0x4df9000, 0x4df8000)
	/Users/jb/src/github.com/syncthing/syncthing/vendor/github.com/syncthing/notify/watcher_fsevents_cgo.go:107 +0x2d2
github.com/syncthing/syncthing/vendor/github.com/syncthing/notify._cgoexpwrap_4ce340c09c06_gostream(0x6b00c30, 0x4, 0x11, 0x6900ef0, 0x4df9000, 0x4df8000)
	_cgo_gotypes.go:399 +0x6b
github.com/syncthing/syncthing/vendor/github.com/syncthing/notify._Cfunc_CFRunLoopRun()
	_cgo_gotypes.go:214 +0x5f
github.com/syncthing/syncthing/vendor/github.com/syncthing/notify.init.1.func1()
	/Users/jb/src/github.com/syncthing/syncthing/vendor/github.com/syncthing/notify/watcher_fsevents_cgo.go:72 +0xce
created by github.com/syncthing/syncthing/vendor/github.com/syncthing/notify.init.1
	/Users/jb/src/github.com/syncthing/syncthing/vendor/github.com/syncthing/notify/watcher_fsevents_cgo.go:65 +0x5c
FAIL	github.com/syncthing/syncthing/lib/fs	0.764s
```

From a quick glance at the code it seems like this could be a race between unwatching and receiving an event from the C code. I believe this change should prevent a panic, but I do not know whether there is an underlying problem that should be addressed instead.