### PR TITLE
Fix Go 1.12beta2 build error

### DIFF
--- a/watcher_fsevents_cgo.go
+++ b/watcher_fsevents_cgo.go
@@ -48,9 +48,7 @@ var wg sync.WaitGroup      // used to wait until the runloop starts
 // started and is ready via the wg. It also serves purpose of a dummy source,
 // thanks to it the runloop does not return as it also has at least one source
 // registered.
-var source = C.CFRunLoopSourceCreate(C.kCFAllocatorDefault, 0, &C.CFRunLoopSourceContext{
-	perform: (C.CFRunLoopPerformCallBack)(C.gosource),
-})
+var source = C.CFRunLoopSourceCreate(C.kCFAllocatorDefault, 0, &C.CFRunLoopSourceContext{perform: (C.CFRunLoopPerformCallBack)(C.gosource)})
 
 // Errors returned when FSEvents functions fail.
 var (


### PR DESCRIPTION
This commit fixes the following build error caused by Go 1.12beta2 on Darwin:

```
./watcher_fsevents_cgo.go:51:69: syntax error: unexpected semicolon, expecting expression
```

I don't understand why `1.12beta2` breaks this but this fixes it. :)

Fixes #169 