### PR TITLE
Forward FSEventsUserDropped, FSEventsKernelDropped, FSEventsMustScanSubDirs

### DIFF
--- a/watcher_fsevents.go
+++ b/watcher_fsevents.go
@@ -129,7 +129,7 @@ func (w *watch) Dispatch(ev []FSEvent) {
 		}
 		dbgprintf("%v (0x%x) (%s, i=%d, ID=%d, len=%d)\n", Event(ev[i].Flags),
 			ev[i].Flags, ev[i].Path, i, ev[i].ID, len(ev))
-		if ev[i].Flags&failure != 0 {
+		if ev[i].Flags&failure != 0 && failure&events == 0 {
 			// TODO(rjeczalik): missing error handling
 			continue
 		}


### PR DESCRIPTION
In its current implementation, the FSEvents watcher ignores and doesn't forward those 3 events. At the very least if they are triggered, the user should be notified if he subscribed to them.