### PR TITLE
Fix Darwin build without Cgo

### DIFF
--- a/event_fsevents.go
+++ b/event_fsevents.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,!kqueue
+// +build darwin,!kqueue,cgo
 
 package notify
 

--- a/event_kqueue.go
+++ b/event_kqueue.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue dragonfly freebsd netbsd openbsd
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd
 
 package notify
 

--- a/event_trigger.go
+++ b/event_trigger.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue dragonfly freebsd netbsd openbsd solaris
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris
 
 package notify
 

--- a/example_fsevents_test.go
+++ b/example_fsevents_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,!kqueue
+// +build darwin,!kqueue,cgo
 
 package notify_test
 

--- a/watcher_fsevents.go
+++ b/watcher_fsevents.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,!kqueue
+// +build darwin,!kqueue,cgo
 
 package notify
 

--- a/watcher_fsevents_cgo.go
+++ b/watcher_fsevents_cgo.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,!kqueue
+// +build darwin,!kqueue,cgo
 
 package notify
 

--- a/watcher_fsevents_test.go
+++ b/watcher_fsevents_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,!kqueue
+// +build darwin,!kqueue,cgo
 
 package notify
 

--- a/watcher_kqueue.go
+++ b/watcher_kqueue.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue dragonfly freebsd netbsd openbsd
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd
 
 package notify
 

--- a/watcher_kqueue_test.go
+++ b/watcher_kqueue_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue dragonfly freebsd netbsd openbsd
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd
 
 package notify
 

--- a/watcher_recursive_test.go
+++ b/watcher_recursive_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,!kqueue windows
+// +build darwin,!kqueue,cgo windows
 
 package notify
 

--- a/watcher_trigger.go
+++ b/watcher_trigger.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue dragonfly freebsd netbsd openbsd solaris
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris
 
 // watcher_trigger is used for FEN and kqueue which behave similarly:
 // only files and dirs can be watched directly, but not files inside dirs.

--- a/watcher_trigger_test.go
+++ b/watcher_trigger_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue dragonfly freebsd netbsd openbsd solaris
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris
 
 package notify
 


### PR DESCRIPTION
Either cross-compiling or explicit `CGO_ENABLED=0`:
```
GOOS=darwin go build
```

Expected output: builds without an error
Actual output:
```
# github.com/rjeczalik/notify
./watcher_fsevents.go:49:11: undefined: stream
```

This PR addresses this issue by adding a fallback to kqueue on `darwin,!cgo` and enabling fsevents only for `darwin,!kqueue,cgo`.