### PR TITLE
Add illumos build tags in the right places

### DIFF
--- a/event_fen.go
+++ b/event_fen.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build solaris
+// +build solaris illumos
 
 package notify
 

--- a/event_stub.go
+++ b/event_stub.go
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 // +build !darwin,!linux,!freebsd,!dragonfly,!netbsd,!openbsd,!windows
-// +build !kqueue,!solaris
+// +build !kqueue,!solaris,!illumos
 
 package notify
 

--- a/event_trigger.go
+++ b/event_trigger.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris illumos
 
 package notify
 

--- a/watcher_fen.go
+++ b/watcher_fen.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build solaris
+// +build solaris illumos
 
 package notify
 

--- a/watcher_fen_cgo.go
+++ b/watcher_fen_cgo.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build solaris
+// +build solaris illumos
 
 package notify
 

--- a/watcher_fen_test.go
+++ b/watcher_fen_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build solaris
+// +build solaris illumos
 
 package notify
 

--- a/watcher_notimplemented.go
+++ b/watcher_notimplemented.go
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 // +build !darwin,!linux,!freebsd,!dragonfly,!netbsd,!openbsd,!windows
-// +build !kqueue,!solaris
+// +build !kqueue,!solaris,!illumos
 
 package notify
 

--- a/watcher_trigger.go
+++ b/watcher_trigger.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris illumos
 
 // watcher_trigger is used for FEN and kqueue which behave similarly:
 // only files and dirs can be watched directly, but not files inside dirs.

--- a/watcher_trigger_test.go
+++ b/watcher_trigger_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris illumos
 
 package notify
 


### PR DESCRIPTION
I added the new illumos build target to the right places analogous to the solaris build tag.

The buildtags inherit from one another so it did build on illumos already but this makes it future proof if the buildtags diverge at some date.

Also, the tests on illumos fail because of missing files?
```text
--- FAIL: TestWatcherFen (0.33s)
    testing_test.go:219: testing_test.go:502: missing events for "notify/testdata/506863856/src/github.com/ppknap/link/include/coost/link/detail/stdhelpers" (notify.FileDelete)
    testing_test.go:219: testing_test.go:300: w.Watcher.Close()=open notify/testdata/506863856/src/github.com/ppknap/link/include/coost/link/detail: no such file or directory
--- FAIL: TestStopPathNotExists (0.60s)
    testing_test.go:219: testing_test.go:300: w.Watcher.Close()=open notify/testdata/603188642/src/github.com/ppknap: no such file or directory
FAIL
FAIL    github.com/rjeczalik/notify     17.235s
FAIL
```