### PR TITLE
kqueue: Ignore errors due to dangling symlinks

### DIFF
--- a/watcher_kqueue.go
+++ b/watcher_kqueue.go
@@ -57,6 +57,12 @@ func (k *kq) Close() error {
 func (*kq) NewWatched(p string, fi os.FileInfo) (*watched, error) {
 	fd, err := syscall.Open(p, syscall.O_NONBLOCK|syscall.O_RDONLY, 0)
 	if err != nil {
+		// BSDs can't open symlinks and return an error if the symlink
+		// cannot be followed - ignore it instead of failing. See e.g.
+		// https://github.com/libinotify-kqueue/libinotify-kqueue/blob/a822c8f1d75404fe3132f695a898dcd42fe8afbc/patches/freebsd11-O_SYMLINK.patch
+		if os.IsNotExist(err) && fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+			return nil, errSkip
+		}
 		return nil, err
 	}
 	return &watched{

--- a/watcher_trigger.go
+++ b/watcher_trigger.go
@@ -151,6 +151,9 @@ func (t *trg) singlewatch(p string, e Event, direct mode, fi os.FileInfo) (err e
 	w, ok := t.pthLkp[p]
 	if !ok {
 		if w, err = t.t.NewWatched(p, fi); err != nil {
+			if err == errSkip {
+				err = nil
+			}
 			return
 		}
 	}


### PR DESCRIPTION
When recursively watching a directory that contains a symlink that points at nothing, it fails with `error while traversing /usr/home/simon/Sync: no such file or directory`. I first wanted to handle that by opening the symlink itself instead of following it, however it turns out that's not supported on BSDs (no `O_SYMLINK`). Ignoring and thus not watching the broken symlink seems more appropriate than failing the entire recursive watch operation.