### PR TITLE
readdcw: Add action to panic msg

### DIFF
--- a/watcher_readdcw.go
+++ b/watcher_readdcw.go
@@ -8,6 +8,7 @@ package notify
 
 import (
 	"errors"
+	"fmt"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -587,7 +588,7 @@ func decode(filter, action uint32) (Event, Event) {
 	case syscall.FILE_ACTION_RENAMED_NEW_NAME:
 		return gensys(filter, Rename, FileActionRenamedNewName)
 	}
-	panic(`notify: cannot decode internal mask`)
+	panic(fmt.Sprintln(`notify: cannot decode internal mask:`, action))
 }
 
 // gensys decides whether the Windows action, system-independent event or both


### PR DESCRIPTION
We are seeing a few reports of these: `panic: notify: cannot decode internal mask`

This adds the action to the panic message, so we can maybe get an idea of what's wrong there.