### PR TITLE
inotify: Fix path when renaming dir in recursive watch

### DIFF
--- a/watcher_inotify.go
+++ b/watcher_inotify.go
@@ -93,20 +93,14 @@ func (i *inotify) watch(path string, e Event) (err error) {
 	if err != nil {
 		return
 	}
-	i.RLock()
-	wd := i.m[int32(iwd)]
-	i.RUnlock()
-	if wd == nil {
-		i.Lock()
-		if i.m[int32(iwd)] == nil {
-			i.m[int32(iwd)] = &watched{path: path, mask: uint32(e)}
-		}
-		i.Unlock()
+	i.Lock()
+	if wd, ok := i.m[int32(iwd)]; !ok {
+		i.m[int32(iwd)] = &watched{path: path, mask: uint32(e)}
 	} else {
-		i.Lock()
+		wd.path = path
 		wd.mask = uint32(e)
-		i.Unlock()
 	}
+	i.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
Steps to reproduce (or just run the test in the PR):

1. Create recursive watch.
2. Create a dir A.
3. Rename the dir to B.
4. Create a file at B/foo

Expected: Event at B/foo

Actual: Event at A/foo

The main fix is in line 100: The path needs to updated too.

I also changed the locking, as both branches of the if require a write-lock, thus acquiring a read-lock first is pointless.

The issue was originally reported in https://github.com/syncthing/syncthing/issues/7076