### PR TITLE
Fixes for non-recursive tree when dirs are deleted (fixes #200)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/rjeczalik/notify
 
+go 1.11
+
 require golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7

--- a/node.go
+++ b/node.go
@@ -122,13 +122,13 @@ func (nd node) Del(name string) error {
 			return errnotexist(name[:i+j])
 		}
 		stack = append(stack, nd)
+		i += j + 1
 	}
-	if nd, ok = nd.Child[name[i:]]; !ok {
+	if _, ok = nd.Child[name[i:]]; !ok {
 		return errnotexist(name)
 	}
-	nd.Child = nil
-	nd.Watch = nil
-	for name, i = base(nd.Name), len(stack); i != 0; name, i = base(nd.Name), i-1 {
+	delete(nd.Child, name[i:])
+	for name, i = name[i:], len(stack); i != 0; name, i = base(nd.Name), i-1 {
 		nd = stack[i-1]
 		if nd := nd.Child[name]; len(nd.Watch) > 1 || len(nd.Child) != 0 {
 			break

--- a/node.go
+++ b/node.go
@@ -49,7 +49,7 @@ func (nd node) addchild(name, base string) node {
 }
 
 func (nd node) Add(name string) node {
-	i := indexbase(nd.Name, name)
+	i := indexrel(nd.Name, name)
 	if i == -1 {
 		return node{}
 	}
@@ -93,7 +93,7 @@ Traverse:
 }
 
 func (nd node) Get(name string) (node, error) {
-	i := indexbase(nd.Name, name)
+	i := indexrel(nd.Name, name)
 	if i == -1 {
 		return node{}, errnotexist(name)
 	}
@@ -111,7 +111,7 @@ func (nd node) Get(name string) (node, error) {
 }
 
 func (nd node) Del(name string) error {
-	i := indexbase(nd.Name, name)
+	i := indexrel(nd.Name, name)
 	if i == -1 {
 		return errnotexist(name)
 	}
@@ -167,7 +167,7 @@ Traverse:
 }
 
 func (nd node) WalkPath(name string, fn walkPathFunc) error {
-	i := indexbase(nd.Name, name)
+	i := indexrel(nd.Name, name)
 	if i == -1 {
 		return errnotexist(name)
 	}

--- a/tree_nonrecursive.go
+++ b/tree_nonrecursive.go
@@ -65,7 +65,7 @@ func (t *nonrecursiveTree) dispatch(c <-chan EventInfo) {
 			}
 			t.rw.RUnlock()
 			// If the event describes newly leaf directory created within
-			if !isrec || ei.Event() != Create {
+			if !isrec || ei.Event()&(Create|Remove) == 0 {
 				return
 			}
 			if ok, err := ei.(isDirer).isDir(); !ok || err != nil {
@@ -79,9 +79,23 @@ func (t *nonrecursiveTree) dispatch(c <-chan EventInfo) {
 // internal TODO(rjeczalik)
 func (t *nonrecursiveTree) internal(rec <-chan EventInfo) {
 	for ei := range rec {
+		t.rw.Lock()
+		if ei.Event() == Remove {
+			nd, err := t.root.Get(ei.Path())
+			if err != nil {
+				t.rw.Unlock()
+				continue
+			}
+			t.walkWatchpoint(nd, func(_ Event, nd node) error {
+				t.w.Unwatch(nd.Name)
+				return nil
+			})
+			t.root.Del(ei.Path())
+			t.rw.Unlock()
+			continue
+		}
 		var nd node
 		var eset = internal
-		t.rw.Lock()
 		t.root.WalkPath(ei.Path(), func(it node, _ bool) error {
 			if e := it.Watch[t.rec]; e != 0 && e > eset {
 				eset = e

--- a/tree_nonrecursive.go
+++ b/tree_nonrecursive.go
@@ -93,7 +93,10 @@ func (t *nonrecursiveTree) internal(rec <-chan EventInfo) {
 			t.rw.Unlock()
 			continue
 		}
-		err := nd.Add(ei.Path()).AddDir(t.recFunc(eset))
+		if ei.Path() != nd.Name {
+			nd = nd.Add(ei.Path())
+		}
+		err := nd.AddDir(t.recFunc(eset))
 		t.rw.Unlock()
 		if err != nil {
 			dbgprintf("internal(%p) error: %v", rec, err)

--- a/util.go
+++ b/util.go
@@ -123,10 +123,12 @@ func base(s string) string {
 	return s
 }
 
-func indexbase(root, name string) int {
-	if n, m := len(root), len(name); m >= n && name[:n] == root &&
-		(n == m || name[n] == os.PathSeparator) {
-		return min(n+1, m)
+// indexrel returns the index of the first char of name that is
+// below/relative to root. It returns -1 if name is not a child of root.
+func indexrel(root, name string) int {
+	if n, m := len(root), len(name); m > n && name[:n] == root &&
+		name[n] == os.PathSeparator {
+		return n + 1
 	}
 	return -1
 }


### PR DESCRIPTION
I added a test based on the example posted in #200.

The main change is to also pass `Remove` events to `t.rec`, and then unwatch and delete nodes under that path. Thus when it gets created again, new watches will be set up (instead of keeping the old, now invalid watches).

I also fixed some stuff I encountered while debugging and fixing:

 - go.mod always changes when running anything like tests. I chose 1.11 because that's when modules started - earlier versions anyway don't care about go.mod.
 - Don't re-add already existing created directories - that lead to empty leave nodes (however shouldn't happen any more now that deleted dirs are removed - still better be safe).
 - `indexbase` is needlessly complicated. All functions where it is called return an error if the root and name are equal. I thus chaned it to return `-1` if `root` and `name` are equal. And renamed it to `indexrel`, as it's the first index of the path relative to root, not the last element in name.