### PR TITLE
Notify when only root drive is selected - do not add additional child…

### DIFF
--- a/node.go
+++ b/node.go
@@ -211,7 +211,7 @@ func (r root) addroot(name string) node {
 	if vol := filepath.VolumeName(name); vol != "" {
 		root, ok := r.nd.Child[vol]
 		if !ok {
-			root = r.nd.addchild(vol, vol)
+			root = r.nd.addchild(vol+string(os.PathSeparator), vol)
 		}
 		return root
 	}
@@ -230,7 +230,11 @@ func (r root) root(name string) (node, error) {
 }
 
 func (r root) Add(name string) node {
-	return r.addroot(name).Add(name)
+	nd := r.addroot(name)
+	if nd.Name == name {
+		return nd
+	}
+	return nd.Add(name)
 }
 
 func (r root) AddDir(dir string, fn walkFunc) error {

--- a/util.go
+++ b/util.go
@@ -126,9 +126,9 @@ func base(s string) string {
 // indexrel returns the index of the first char of name that is
 // below/relative to root. It returns -1 if name is not a child of root.
 func indexrel(root, name string) int {
-	if n, m := len(root), len(name); m > n && name[:n] == root &&
-		name[n] == os.PathSeparator {
-		return n + 1
+	if n, m := len(root), len(name); m > n-1 && name[:n] == root &&
+		name[n-1] == os.PathSeparator {
+		return n
 	}
 	return -1
 }


### PR DESCRIPTION
If watch path is root drive ("C:\\...") then watchpoint tree creates a child node with empty string as key. This breaks code.