### PR TITLE
readdcw: fix checkptr failure in loopevent under -race builds

### DIFF
--- a/watcher_readdcw.go
+++ b/watcher_readdcw.go
@@ -403,7 +403,7 @@ func (r *readdcw) loopevent(n uint32, overEx *overlappedEx) {
 	var currOffset uint32
 	for {
 		raw := (*syscall.FileNotifyInformation)(unsafe.Pointer(&overEx.parent.buffer[currOffset]))
-		name := syscall.UTF16ToString((*[syscall.MAX_LONG_PATH]uint16)(unsafe.Pointer(&raw.FileName))[:raw.FileNameLength>>1])
+		name := syscall.UTF16ToString(unsafe.Slice(&raw.FileName, raw.FileNameLength>>1))
 		events = append(events, &event{
 			pathw:  overEx.parent.pathw,
 			filter: overEx.parent.filter,


### PR DESCRIPTION
Hey, ran into this rare race condition in our test suite.. figured i should send a fix

Any program built with `-race` (or `-d=checkptr`) that watches a directory on Windows aborts on the first delivered filesystem event:

```
fatal error: checkptr: converted pointer straddles multiple allocations
  github.com/rjeczalik/notify.(*readdcw).loopevent
  watcher_readdcw.go:406
```

`loopevent` extracts the file name from each `FILE_NOTIFY_INFORMATION` record by casting the `FileName` pointer to a fixed-size array:

```go
name := syscall.UTF16ToString((*[syscall.MAX_LONG_PATH]uint16)(unsafe.Pointer(&raw.FileName))[:raw.FileNameLength>>1])
```

`syscall.MAX_LONG_PATH` is 32768, so the conversion asserts a 64 KiB pointee starting inside the 4 KiB read buffer (`readBufferSize = 4096`). That extends far past the end of the allocation, which violates the checkptr rule that a converted pointer must fit within a single allocation, and the runtime aborts before the slice expression can narrow it. Normal builds are unaffected because only `FileNameLength/2` elements are ever read.

The fix replaces the fake-array idiom with `unsafe.Slice` (Go 1.17+), bounded by the record's actual `FileNameLength`:

```go
name := syscall.UTF16ToString(unsafe.Slice(&raw.FileName, raw.FileNameLength>>1))
```

The span stays inside the buffer the kernel wrote the name into, so checkptr passes and behavior is unchanged.

Found while running MinIO client's watch tests under `-race` on Windows CI; verified there that the crash reproduces before this change and disappears after it (`GOOS=windows go build ./...` and `go vet` also pass).
